### PR TITLE
Add "ghost" render layer

### DIFF
--- a/src/main/java/com/mattworzala/debug/client/render/RenderLayer.java
+++ b/src/main/java/com/mattworzala/debug/client/render/RenderLayer.java
@@ -1,10 +1,12 @@
 package com.mattworzala.debug.client.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import org.lwjgl.opengl.GL11;
 
 public enum RenderLayer {
-    INLINE(RenderSystem::enableDepthTest),
-    TOP(RenderSystem::disableDepthTest);
+    INLINE(() -> {}),
+    TOP(RenderSystem::disableDepthTest),
+    GHOST(() -> RenderSystem.depthMask(false));
 
     private final Runnable setup;
     RenderLayer(Runnable setup) { this.setup = setup; }

--- a/src/main/java/com/mattworzala/debug/client/render/RenderLayer.java
+++ b/src/main/java/com/mattworzala/debug/client/render/RenderLayer.java
@@ -1,17 +1,6 @@
 package com.mattworzala.debug.client.render;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-import org.lwjgl.opengl.GL11;
-
 public enum RenderLayer {
-    INLINE(() -> {}),
-    TOP(RenderSystem::disableDepthTest),
-    GHOST(() -> RenderSystem.depthMask(false));
-
-    private final Runnable setup;
-    RenderLayer(Runnable setup) { this.setup = setup; }
-
-    public void setup() {
-        setup.run();
-    }
+    INLINE,
+    TOP
 }

--- a/src/main/java/com/mattworzala/debug/client/render/Shape.java
+++ b/src/main/java/com/mattworzala/debug/client/render/Shape.java
@@ -6,6 +6,7 @@ import org.lwjgl.opengl.GL11;
 public abstract class Shape {
 
     public RenderLayer layer = RenderLayer.INLINE;
+    public int argb = 0xFFFFFFFF;
 
     public void render(double cameraX, double cameraY, double cameraZ) {
         // Setup
@@ -14,12 +15,19 @@ public abstract class Shape {
         RenderSystem.setShaderColor(1, 1, 1, 1);
         RenderSystem.disableTexture();
         RenderSystem.enableDepthTest();
-        layer.setup();
+
+        if (layer == RenderLayer.INLINE) {
+            int alpha = (argb >> 24) & 0xFF;
+            if (alpha < 240) {
+                RenderSystem.depthMask(false);
+            }
+        } else if (layer == RenderLayer.TOP) {
+            RenderSystem.disableDepthTest();
+        }
 
         render0(cameraX, cameraY, cameraZ);
 
         // Cleanup
-        RenderSystem.depthFunc(GL11.GL_LEQUAL);
         RenderSystem.depthMask(true);
         RenderSystem.enableTexture();
         RenderSystem.disableBlend();

--- a/src/main/java/com/mattworzala/debug/client/render/Shape.java
+++ b/src/main/java/com/mattworzala/debug/client/render/Shape.java
@@ -1,6 +1,7 @@
 package com.mattworzala.debug.client.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import org.lwjgl.opengl.GL11;
 
 public abstract class Shape {
 
@@ -12,11 +13,14 @@ public abstract class Shape {
         RenderSystem.defaultBlendFunc();
         RenderSystem.setShaderColor(1, 1, 1, 1);
         RenderSystem.disableTexture();
+        RenderSystem.enableDepthTest();
         layer.setup();
 
         render0(cameraX, cameraY, cameraZ);
 
         // Cleanup
+        RenderSystem.depthFunc(GL11.GL_LEQUAL);
+        RenderSystem.depthMask(true);
         RenderSystem.enableTexture();
         RenderSystem.disableBlend();
     }

--- a/src/main/java/com/mattworzala/debug/client/render/shape/BoxShape.java
+++ b/src/main/java/com/mattworzala/debug/client/render/shape/BoxShape.java
@@ -12,7 +12,6 @@ public class BoxShape extends Shape {
     public final double x2;
     public final double y2;
     public final double z2;
-    public final int argb;
 
     public BoxShape(PacketByteBuf buffer) {
         x1 = buffer.readDouble();

--- a/src/main/java/com/mattworzala/debug/client/render/shape/LineShape.java
+++ b/src/main/java/com/mattworzala/debug/client/render/shape/LineShape.java
@@ -12,7 +12,6 @@ import java.util.List;
 public class LineShape extends Shape {
     public final List<Vec3d> points;
     public final float lineWidth;
-    public final int argb;
 
     public LineShape(PacketByteBuf buffer) {
         points = buffer.readList(b -> new Vec3d(b.readDouble(), b.readDouble(), b.readDouble()));

--- a/src/main/java/com/mattworzala/debug/client/render/shape/TextShape.java
+++ b/src/main/java/com/mattworzala/debug/client/render/shape/TextShape.java
@@ -9,7 +9,6 @@ import net.minecraft.util.math.Vec3d;
 public class TextShape extends Shape {
     public final Vec3d position;
     public final String content;
-    public final int argb;
     public final float size;
 
     public TextShape(PacketByteBuf buffer) {


### PR DESCRIPTION
Ghost render layer renders with depth testing (like inline) but doesn't write to the depth buffer (like top).

This is desirable in order to avoid this issue:
TOP -> https://cdn.discordapp.com/attachments/742918027036852227/945987083112157214/unknown.png
GHOST -> https://cdn.discordapp.com/attachments/742918027036852227/945994585170149406/unknown.png

(Might need a better name)