### PR TITLE
Update Minestom

### DIFF
--- a/minestom/build.gradle
+++ b/minestom/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.mattworzala.debug'
-version '1.19.1'
+version '1.19.2'
 
 repositories {
     mavenCentral()
@@ -12,9 +12,9 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'com.github.Minestom:Minestom:a04012d9bf'
+    compileOnly 'com.github.Minestom:Minestom:42195c536b'
 
-    testImplementation 'com.github.Minestom:Minestom:a04012d9bf'
+    testImplementation 'com.github.Minestom:Minestom:42195c536b'
 }
 
 java {


### PR DESCRIPTION
Updates Minestom to the latest version (as of creation) `42195c536b`. With this, the module version has been bumped to `1.19.2`.