### PR TITLE
[Minestom] Use Points instead of Vecs

### DIFF
--- a/minestom/src/main/java/com/mattworzala/debug/shape/Box.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Box.java
@@ -1,14 +1,14 @@
 package com.mattworzala.debug.shape;
 
 import com.mattworzala.debug.Layer;
-import net.minestom.server.coordinate.Vec;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
 public record Box(
-        Vec start,
-        Vec end,
+        Point start,
+        Point end,
         int color,
         Layer layer
 ) implements Shape {
@@ -28,17 +28,17 @@ public record Box(
     }
 
     public static class Builder {
-        private Vec start;
-        private Vec end;
+        private Point start;
+        private Point end;
         private int color = 0xFFFFFFFF;
         private Layer layer = Layer.INLINE;
 
-        public Builder start(Vec start) {
+        public Builder start(Point start) {
             this.start = start;
             return this;
         }
 
-        public Builder end(Vec end) {
+        public Builder end(Point end) {
             this.end = end;
             return this;
         }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/Line.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Line.java
@@ -1,7 +1,7 @@
 package com.mattworzala.debug.shape;
 
 import com.mattworzala.debug.Layer;
-import net.minestom.server.coordinate.Vec;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public record Line(
-        List<Vec> points,
+        List<Point> points,
         float thickness,
         int color,
         Layer layer
@@ -21,7 +21,7 @@ public record Line(
     public void write(@NotNull BinaryWriter buffer) {
         buffer.writeVarInt(ID);
         buffer.writeVarInt(points.size());
-        for (Vec point : points) {
+        for (Point point : points) {
             buffer.writeDouble(point.x());
             buffer.writeDouble(point.y());
             buffer.writeDouble(point.z());
@@ -32,12 +32,12 @@ public record Line(
     }
 
     public static class Builder {
-        private final List<Vec> points = new ArrayList<>();
+        private final List<Point> points = new ArrayList<>();
         private float thickness = 0.1f;
         private int color = 0xFFFFFFFF;
         private Layer layer = Layer.INLINE;
 
-        public Builder point(Vec point) {
+        public Builder point(Point point) {
             points.add(point);
             return this;
         }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/OutlineBox.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/OutlineBox.java
@@ -1,14 +1,14 @@
 package com.mattworzala.debug.shape;
 
 import com.mattworzala.debug.Layer;
-import net.minestom.server.coordinate.Vec;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
 public record OutlineBox(
-        Vec start,
-        Vec end,
+        Point start,
+        Point end,
         int color,
         Layer layer,
         int colorLine,
@@ -39,8 +39,8 @@ public record OutlineBox(
     }
 
     public static class Builder {
-        private Vec start;
-        private Vec end;
+        private Point start;
+        private Point end;
         private int color = 0xFFFFFFFF;
         private Layer layer = Layer.INLINE;
         private int colorLine = 0xFFFFFFFF;
@@ -48,12 +48,12 @@ public record OutlineBox(
         private String text = null;
         private int colorText = 0xFFFFFFFF;
 
-        public Builder start(Vec start) {
+        public Builder start(Point start) {
             this.start = start;
             return this;
         }
 
-        public Builder end(Vec end) {
+        public Builder end(Point end) {
             this.end = end;
             return this;
         }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/Text.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Text.java
@@ -1,13 +1,13 @@
 package com.mattworzala.debug.shape;
 
 import com.mattworzala.debug.Layer;
-import net.minestom.server.coordinate.Vec;
+import net.minestom.server.coordinate.Point;
 import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
 public record Text(
-        Vec position,
+        Point position,
         String content,
         int color,
         float size,
@@ -28,13 +28,13 @@ public record Text(
     }
 
     public static class Builder {
-        private Vec position;
+        private Point position;
         private String content;
         private int color = 0xFFFFFFFF;
         private float size = 0.02f;
         private Layer layer = Layer.INLINE;
 
-        public Builder position(Vec position) {
+        public Builder position(Point position) {
             this.position = position;
             return this;
         }


### PR DESCRIPTION
Converts all Minestom classes to use `Point`s instead of `Vec`s. This allows any class that implements Point to be used, like `Pos`. Functionally this is the same since no Vec-specific methods were used anywhere.