### PR TITLE
Write Javadocs for the Minestom API

### DIFF
--- a/minestom/src/main/java/com/mattworzala/debug/DebugMessage.java
+++ b/minestom/src/main/java/com/mattworzala/debug/DebugMessage.java
@@ -2,7 +2,6 @@ package com.mattworzala.debug;
 
 import com.mattworzala.debug.shape.Shape;
 import net.kyori.adventure.audience.Audience;
-import net.minestom.server.entity.Player;
 import net.minestom.server.network.packet.server.play.PluginMessagePacket;
 import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.utils.PacketUtils;
@@ -11,17 +10,32 @@ import net.minestom.server.utils.binary.BinaryWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A message to send the client to show debug objects.
+ *
+ * @param ops The operations to perform.
+ */
 public record DebugMessage(
         List<Operation> ops
 ) {
+
+    /**
+     * @return A new {@link DebugMessage.Builder}.
+     */
     public static Builder builder() {
         return new Builder();
     }
 
+    /**
+     * Sends this DebugMessage to an audience.
+     */
     public void sendTo(Audience audience) {
         PacketUtils.sendPacket(audience, getPacket());
     }
 
+    /**
+     * @return The packet to send to an audience.
+     */
     public PluginMessagePacket getPacket() {
         BinaryWriter writer = new BinaryWriter(1024);
         writer.writeVarInt(ops.size());
@@ -33,21 +47,48 @@ public record DebugMessage(
 
 
     public static class Builder {
+
         private final List<Operation> ops = new ArrayList<>();
 
+        /**
+         * Sets a shape with the specified namespace ID.
+         *
+         * @param namespaceId The namespace ID for this shape. If reused, the previous shape will be replaced.
+         * @param shape       The shape to associate with the namespace ID.
+         * @return The builder.
+         */
         public Builder set(String namespaceId, Shape shape) {
             return set(NamespaceID.from(namespaceId), shape);
         }
 
+        /**
+         * Sets a shape with the specified namespace ID.
+         *
+         * @param id    The namespace ID for this shape. If reused, the previous shape will be replaced.
+         * @param shape The shape to associate with the namespace ID.
+         * @return The builder.
+         */
         public Builder set(NamespaceID id, Shape shape) {
             ops.add(new Operation.Set(id, shape));
             return this;
         }
 
+        /**
+         * Removes a shape with a specified namespace ID.
+         *
+         * @param namespaceId The namespace ID to remove.
+         * @return The builder.
+         */
         public Builder remove(String namespaceId) {
             return remove(NamespaceID.from(namespaceId));
         }
 
+        /**
+         * Removes a shape with a specified namespace ID.
+         *
+         * @param id The namespace ID to remove.
+         * @return The builder.
+         */
         public Builder remove(NamespaceID id) {
             ops.add(new Operation.Remove(id));
             return this;
@@ -63,8 +104,13 @@ public record DebugMessage(
             return this;
         }
 
+        /**
+         * @return Constructs a new {@link DebugMessage} with the provided builder parameters.
+         */
         public DebugMessage build() {
             return new DebugMessage(ops);
         }
+
     }
+
 }

--- a/minestom/src/main/java/com/mattworzala/debug/Layer.java
+++ b/minestom/src/main/java/com/mattworzala/debug/Layer.java
@@ -1,5 +1,15 @@
 package com.mattworzala.debug;
 
+/**
+ * The Layer determines what layer debug objects should be rendered on.
+ */
 public enum Layer {
-    INLINE, TOP
+    /**
+     * Objects should be rendered normally.
+     */
+    INLINE,
+    /**
+     * Objects should be rendered on-top of everything else.
+     */
+    TOP
 }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/Box.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Box.java
@@ -6,12 +6,21 @@ import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A solid cube.
+ *
+ * @param start The starting corner of the cube.
+ * @param end   The ending corner of the cube.
+ * @param color The color of the cube, in ARGB format.
+ * @param layer The layer of the cube.
+ */
 public record Box(
         Vec start,
         Vec end,
         int color,
         Layer layer
 ) implements Shape {
+
     private static final int ID = 0;
 
     @Override
@@ -28,35 +37,69 @@ public record Box(
     }
 
     public static class Builder {
+
         private Vec start;
         private Vec end;
         private int color = 0xFFFFFFFF;
         private Layer layer = Layer.INLINE;
 
+        /**
+         * The starting corner of the box. Must be set.
+         *
+         * @param start The position.
+         * @return The builder.
+         */
         public Builder start(Vec start) {
             this.start = start;
             return this;
         }
 
+        /**
+         * The ending corner of the box. Must be set.
+         *
+         * @param end The position.
+         * @return The builder.
+         */
         public Builder end(Vec end) {
             this.end = end;
             return this;
         }
 
+        /**
+         * The color of the box in ARGB format.
+         * <p>
+         * Defaults to pure white if not set.
+         *
+         * @param color The color.
+         * @return The builder.
+         */
         public Builder color(int color) {
             this.color = color;
             return this;
         }
 
+        /**
+         * The {@link Layer} of the box.
+         * <p>
+         * Defaults to {@link Layer#INLINE} if not set.
+         *
+         * @param layer The layer.
+         * @return The builder.
+         */
         public Builder layer(Layer layer) {
             this.layer = layer;
             return this;
         }
 
+        /**
+         * @return A {@link Box} constructed from the builder parameters.
+         */
         public Box build() {
             Check.notNull(start, "start");
             Check.notNull(end, "end");
             return new Box(start, end, color, layer);
         }
+
     }
+
 }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/Line.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Line.java
@@ -9,12 +9,21 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A line connected with multiple points.
+ *
+ * @param points    The points the line should go through.
+ * @param thickness The thickness of the line.
+ * @param color     The color of the line, in ARGB format.
+ * @param layer     The layer of the line.
+ */
 public record Line(
         List<Vec> points,
         float thickness,
         int color,
         Layer layer
 ) implements Shape {
+
     private static final int ID = 1;
 
     @Override
@@ -32,11 +41,20 @@ public record Line(
     }
 
     public static class Builder {
+
         private final List<Vec> points = new ArrayList<>();
         private float thickness = 0.1f;
         private int color = 0xFFFFFFFF;
         private Layer layer = Layer.INLINE;
 
+        /**
+         * Adds a point to the line.
+         * Lines will be rendered in order from the first point to the last.
+         * There must be at least 2 points to render a line.
+         *
+         * @param point The point.
+         * @return The builder.
+         */
         public Builder point(Vec point) {
             points.add(point);
             return this;
@@ -47,19 +65,40 @@ public record Line(
             return this;
         }
 
+        /**
+         * The color of the line in ARGB format.
+         * <p>
+         * Defaults to pure white if not set.
+         *
+         * @param color The color.
+         * @return The builder.
+         */
         public Builder color(int color) {
             this.color = color;
             return this;
         }
 
+        /**
+         * The {@link Layer} of the line.
+         * <p>
+         * Defaults to {@link Layer#INLINE} if not set.
+         *
+         * @param layer The layer.
+         * @return The builder.
+         */
         public Builder layer(Layer layer) {
             this.layer = layer;
             return this;
         }
 
+        /**
+         * @return A {@link Line} constructed from the builder parameters.
+         */
         public Line build() {
             Check.argCondition(points.size() < 2, "Line must have at least 2 points");
             return new Line(points, thickness, color, layer);
         }
+
     }
+
 }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/OutlineBox.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/OutlineBox.java
@@ -16,6 +16,7 @@ public record OutlineBox(
         String text,
         int colorText
 ) implements Shape {
+
     private static final int ID = 3;
 
     @Override
@@ -39,6 +40,7 @@ public record OutlineBox(
     }
 
     public static class Builder {
+
         private Vec start;
         private Vec end;
         private int color = 0xFFFFFFFF;
@@ -48,11 +50,23 @@ public record OutlineBox(
         private String text = null;
         private int colorText = 0xFFFFFFFF;
 
+        /**
+         * The starting corner of the box. Must be set.
+         *
+         * @param start The position.
+         * @return The builder.
+         */
         public Builder start(Vec start) {
             this.start = start;
             return this;
         }
 
+        /**
+         * The ending corner of the box. Must be set.
+         *
+         * @param end The position.
+         * @return The builder.
+         */
         public Builder end(Vec end) {
             this.end = end;
             return this;
@@ -63,6 +77,14 @@ public record OutlineBox(
             return this;
         }
 
+        /**
+         * The {@link Layer} of the box.
+         * <p>
+         * Defaults to {@link Layer#INLINE} if not set.
+         *
+         * @param layer The layer.
+         * @return The builder.
+         */
         public Builder layer(Layer layer) {
             this.layer = layer;
             return this;
@@ -93,5 +115,7 @@ public record OutlineBox(
             Check.notNull(end, "end");
             return new OutlineBox(start, end, color, layer, colorLine, layerLine, text, colorText);
         }
+
     }
+
 }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/Shape.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Shape.java
@@ -3,16 +3,29 @@ package com.mattworzala.debug.shape;
 import net.minestom.server.utils.binary.BinaryWriter;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A shape that can be rendered.
+ * New shapes cannot be added without a rendered also being added to the client-side mod.
+ */
 public interface Shape {
 
+    /**
+     * @return A new {@link Box.Builder}.
+     */
     static Box.Builder box() {
         return new Box.Builder();
     }
 
+    /**
+     * @return A new {@link Line.Builder}.
+     */
     static Line.Builder line() {
         return new Line.Builder();
     }
 
+    /**
+     * @return A new {@link Text.Builder}.
+     */
     static Text.Builder text() {
         return new Text.Builder();
     }

--- a/minestom/src/main/java/com/mattworzala/debug/shape/Text.java
+++ b/minestom/src/main/java/com/mattworzala/debug/shape/Text.java
@@ -6,6 +6,15 @@ import net.minestom.server.utils.binary.BinaryWriter;
 import net.minestom.server.utils.validate.Check;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Text.
+ *
+ * @param position The position of the text.
+ * @param content  What the text should say.
+ * @param color    The color of the cube, in ARGB format.
+ * @param size     The size of text, in arbitrary units.
+ * @param layer    The layer of the cube.
+ */
 public record Text(
         Vec position,
         String content,
@@ -13,6 +22,7 @@ public record Text(
         float size,
         Layer layer
 ) implements Shape {
+
     private static final int ID = 2;
 
     @Override
@@ -28,41 +38,83 @@ public record Text(
     }
 
     public static class Builder {
+
         private Vec position;
         private String content;
         private int color = 0xFFFFFFFF;
         private float size = 0.02f;
         private Layer layer = Layer.INLINE;
 
+        /**
+         * The position to render the text. Must be set.
+         *
+         * @param position The position.
+         * @return The builder.
+         */
         public Builder position(Vec position) {
             this.position = position;
             return this;
         }
 
+        /**
+         * The text to show. Must be set.
+         *
+         * @param content The text.
+         * @return The builder.
+         */
         public Builder content(String content) {
             this.content = content;
             return this;
         }
 
+        /**
+         * The color of the box in ARGB format.
+         * <p>
+         * Defaults to pure white if not set.
+         *
+         * @param color The color.
+         * @return The builder.
+         */
         public Builder color(int color) {
             this.color = color;
             return this;
         }
 
+        /**
+         * The size of the text, in arbitrary units.
+         * <p>
+         * Defaults to 0.02 if not set.
+         *
+         * @param size The size.
+         * @return The builder.
+         */
         public Builder size(float size) {
             this.size = size;
             return this;
         }
 
+        /**
+         * The {@link Layer} of the box.
+         * <p>
+         * Defaults to {@link Layer#INLINE} if not set.
+         *
+         * @param layer The layer.
+         * @return The builder.
+         */
         public Builder layer(Layer layer) {
             this.layer = layer;
             return this;
         }
 
+        /**
+         * @return A {@link Text} constructed from the builder parameters.
+         */
         public Text build() {
             Check.notNull(position, "position");
             Check.notNull(content, "content");
             return new Text(position, content, color, size, layer);
         }
+
     }
+
 }


### PR DESCRIPTION
Adds Javadocs for most of the Minestom API, excluding the `Operation` interface.

The methods I didn't add Javadocs to are because they don't seem to actually work. If you'd like I can document what they're supposed to do anyways. The biggest offender of this is the OutlineBox, which seems to be mostly broken as most of the builder methods don't change anything, and their values aren't used in the renderer.

Please read all of the docs uncase any of them are wrong, which they might be since I haven't been using this library very long.