### PR TITLE
Update Modrinth game version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ modrinth {
     versionNumber = project.version.toString()
     versionType = "release"
     uploadFile = remapJar
-    gameVersions = ["1.19.4"]
+    gameVersions = ["1.20.1"]
     dependencies {
         required.project "fabric-api"
     }


### PR DESCRIPTION
The latest Modrinth release for 1.20.1 has the game version set as 1.19.4, breaking auto updaters in launchers like Prism Launcher. This updates the listed game versions for future builds; however, the existing build will need to be updated manually.